### PR TITLE
v0.2: durable earcon library + first-run starter generation

### DIFF
--- a/skills/local-tts-queue/SKILL.md
+++ b/skills/local-tts-queue/SKILL.md
@@ -32,12 +32,14 @@ Use this skill to keep local speech fast, reliable, and policy-compliant by trea
 - First-run interactive setup: `skills/local-tts-queue/scripts/setup-first-run.sh`
 - Backend detection (OS-aware): `skills/local-tts-queue/scripts/backend-detect.sh`
 - ElevenLabs capability preflight: `skills/local-tts-queue/scripts/elevenlabs-preflight.sh`
+- Earcon library manager (durable categories/cache): `skills/local-tts-queue/scripts/earcon-library.sh`
 
 ## References map
 - Runbook: `references/runbook.md`
 - Config contract: `references/config-contract.md`
 - Performance SLOs and interpretation: `references/perf-slos.md`
 - Foreground-latency optimization: `references/front-path-optimization.md`
+- Durable earcon categories and cache: `references/earcon-library.md`
 
 ## Execution checklist
 - Verify prerequisites (`ELEVENLABS_API_KEY`, `ELEVENLABS_VOICE_ID`, `mpv`).

--- a/skills/local-tts-queue/references/earcon-library.md
+++ b/skills/local-tts-queue/references/earcon-library.md
@@ -1,0 +1,31 @@
+# Earcon Library (Durable)
+
+Use `scripts/earcon-library.sh` to manage persistent earcons by category.
+
+## Categories
+- `start`
+- `end`
+- `update`
+- `important`
+- `error`
+
+## Commands
+```bash
+# Initialize library file
+skills/local-tts-queue/scripts/earcon-library.sh init
+
+# List current category mappings
+skills/local-tts-queue/scripts/earcon-library.sh list
+
+# Show categories without assigned files
+skills/local-tts-queue/scripts/earcon-library.sh missing
+
+# Generate/update one category via ElevenLabs SFX
+skills/local-tts-queue/scripts/earcon-library.sh generate important "arena horn with reverb" 2
+```
+
+## Durability behavior
+- Generated files are stored under `audio/earcons/`.
+- Metadata is stored in `earcons.libraryPath` (default `.openclaw/earcon-library.json`).
+- Category mappings are written into `config/tts-queue.json` and reused.
+- No per-message regeneration is required once categories are populated.

--- a/skills/local-tts-queue/scripts/earcon-library.sh
+++ b/skills/local-tts-queue/scripts/earcon-library.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+CFG="$ROOT/config/tts-queue.json"
+EARCON_DIR="$ROOT/audio/earcons"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  earcon-library.sh init
+  earcon-library.sh list
+  earcon-library.sh missing
+  earcon-library.sh generate <category> [prompt] [duration_seconds]
+
+Categories: start | end | update | important | error
+Notes:
+- Requires config/tts-queue.json (create via setup-first-run.sh)
+- Requires ELEVENLABS_API_KEY for generate
+EOF
+}
+
+[[ $# -ge 1 ]] || { usage; exit 2; }
+cmd="$1"; shift
+
+[[ -f "$CFG" ]] || { echo "missing config: $CFG" >&2; exit 1; }
+mkdir -p "$EARCON_DIR" "$ROOT/.openclaw"
+
+read_cfg() {
+  python3 - "$CFG" <<'PY'
+import json,sys
+cfg=json.load(open(sys.argv[1]))
+ear=cfg.setdefault('earcons',{})
+ear.setdefault('libraryPath','.openclaw/earcon-library.json')
+ear.setdefault('categories',{})
+print(ear['libraryPath'])
+for k in ('start','end','update','important','error'):
+    print(ear['categories'].get(k,''))
+PY
+}
+
+mapfile -t cfgvals < <(read_cfg)
+LIB_PATH_RAW="${cfgvals[0]}"
+if [[ "$LIB_PATH_RAW" = /* ]]; then
+  LIB_PATH="$LIB_PATH_RAW"
+else
+  LIB_PATH="$ROOT/$LIB_PATH_RAW"
+fi
+
+ensure_lib() {
+  [[ -f "$LIB_PATH" ]] || echo '{"version":1,"earcons":{}}' > "$LIB_PATH"
+}
+
+ensure_lib
+
+case "$cmd" in
+  init)
+    echo "initialized library: $LIB_PATH"
+    ;;
+  list)
+    python3 - "$LIB_PATH" <<'PY'
+import json,sys
+lib=json.load(open(sys.argv[1]))
+for k,v in lib.get('earcons',{}).items():
+    print(f"{k}\t{v.get('path','')}\t{v.get('created_at','')}")
+PY
+    ;;
+  missing)
+    python3 - "$CFG" <<'PY'
+import json,sys
+cfg=json.load(open(sys.argv[1]))
+cats=cfg.get('earcons',{}).get('categories',{})
+need=['start','end','update','important','error']
+missing=[c for c in need if not cats.get(c)]
+print('\n'.join(missing))
+PY
+    ;;
+  generate)
+    [[ $# -ge 1 ]] || { usage; exit 2; }
+    category="$1"; shift
+    prompt="${1:-}"
+    duration="${2:-1}"
+    case "$category" in start|end|update|important|error) ;; *) echo "invalid category: $category" >&2; exit 2;; esac
+    [[ -n "${ELEVENLABS_API_KEY:-}" ]] || { echo "missing ELEVENLABS_API_KEY" >&2; exit 1; }
+
+    if [[ -z "$prompt" ]]; then
+      case "$category" in
+        start) prompt="subtle startup notification chime, short and clean";;
+        end) prompt="soft completion chime, gentle resolve";;
+        update) prompt="brief status update blip, modern UI sound";;
+        important) prompt="attention notification tone, clear and confident";;
+        error) prompt="short error alert tone, distinct but not harsh";;
+      esac
+    fi
+
+    ts=$(date +%s)
+    out="$EARCON_DIR/${category}-${ts}.mp3"
+    code=$(curl -sS -o "$out" -w '%{http_code}' -X POST "https://api.elevenlabs.io/v1/sound-generation" \
+      -H "xi-api-key: ${ELEVENLABS_API_KEY}" \
+      -H 'Content-Type: application/json' \
+      -d "{\"text\":\"$prompt\",\"duration_seconds\":$duration}")
+
+    if [[ "$code" != "200" ]]; then
+      echo "generation failed http=$code" >&2
+      head -c 240 "$out" || true
+      exit 1
+    fi
+
+    sha=$(sha256sum "$out" | awk '{print $1}')
+    model="${ELEVENLABS_MODEL_ID:-eleven_text_to_sound_v2}"
+    created=$(date -Iseconds)
+
+    python3 - "$CFG" "$LIB_PATH" "$category" "$out" "$prompt" "$model" "$duration" "$sha" "$created" <<'PY'
+import json,sys
+cfgp,libp,cat,path,prompt,model,dur,sha,created=sys.argv[1:]
+cfg=json.load(open(cfgp))
+ear=cfg.setdefault('earcons',{})
+ear.setdefault('categories',{})
+ear['categories'][cat]=path
+json.dump(cfg,open(cfgp,'w'),indent=2)
+
+lib=json.load(open(libp))
+lib.setdefault('version',1)
+lib.setdefault('earcons',{})
+lib['earcons'][cat]={
+  'path':path,
+  'prompt':prompt,
+  'model':model,
+  'duration_seconds':float(dur),
+  'sha256':sha,
+  'created_at':created
+}
+json.dump(lib,open(libp,'w'),indent=2)
+PY
+    echo "generated $category -> $out"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/skills/local-tts-queue/scripts/setup-first-run.sh
+++ b/skills/local-tts-queue/scripts/setup-first-run.sh
@@ -39,11 +39,11 @@ cat > "$CFG" <<EOF
     "enabled": $([[ "$earcons" =~ ^[Yy]$ ]] && echo true || echo false),
     "style": "${style}",
     "categories": {
-      "start": "$EARCON_DIR/start.mp3",
-      "end": "$EARCON_DIR/end.mp3",
-      "update": "$EARCON_DIR/update.mp3",
-      "important": "$EARCON_DIR/important.mp3",
-      "error": "$EARCON_DIR/error.mp3"
+      "start": "",
+      "end": "",
+      "update": "",
+      "important": "",
+      "error": ""
     },
     "libraryPath": "$ROOT/.openclaw/earcon-library.json"
   },
@@ -55,3 +55,14 @@ EOF
 
 echo "Wrote $CFG"
 echo "Next: run skills/local-tts-queue/scripts/elevenlabs-preflight.sh"
+
+if [[ "$earcons" =~ ^[Yy]$ ]]; then
+  read -r -p "Generate starter earcons now? (y/n) [y]: " gen
+  gen=${gen:-y}
+  if [[ "$gen" =~ ^[Yy]$ ]]; then
+    for cat in start end update important error; do
+      "$ROOT/skills/local-tts-queue/scripts/earcon-library.sh" generate "$cat" "${style} ${cat} notification sound" 1 || true
+    done
+    echo "Starter earcons generated (where API/key permits)."
+  fi
+fi


### PR DESCRIPTION
Builds durable earcon support with category mapping and metadata cache.

Includes:
- new earcon-library.sh manager with commands: init, list, missing, generate
- setup wizard now writes empty category map and can generate starter earcons once
- new reference doc for durable earcons
- SKILL.md command/reference updates

Related: #7 #6