### PR TITLE
v0.2: finalize playback validation + ElevenLabs preflight resilience

### DIFF
--- a/skills/local-tts-queue/SKILL.md
+++ b/skills/local-tts-queue/SKILL.md
@@ -31,9 +31,10 @@ Use this skill to keep local speech fast, reliable, and policy-compliant by trea
   - Full diagnostic benchmark: `scripts/benchmark-local-tts-queue.sh 5 --status both --output full`
 - First-run interactive setup: `skills/local-tts-queue/scripts/setup-first-run.sh`
 - Backend detection (OS-aware): `skills/local-tts-queue/scripts/backend-detect.sh`
-- ElevenLabs capability preflight: `skills/local-tts-queue/scripts/elevenlabs-preflight.sh`
+- ElevenLabs capability preflight: `skills/local-tts-queue/scripts/elevenlabs-preflight.sh` (includes short 429 retry/backoff for SFX probe)
 - Earcon library manager (durable categories/cache): `skills/local-tts-queue/scripts/earcon-library.sh`
 - Cross-platform playback runner: `skills/local-tts-queue/scripts/play-local-audio.sh`
+- Playback backend startup validator: `skills/local-tts-queue/scripts/playback-validate.sh`
 - v0.2 smoke tests: `skills/local-tts-queue/scripts/test-v0.2.sh`
 
 ## References map

--- a/skills/local-tts-queue/references/runbook.md
+++ b/skills/local-tts-queue/references/runbook.md
@@ -3,49 +3,67 @@
 ## 1) Validate prerequisites
 - Environment:
   - `ELEVENLABS_API_KEY`
-  - `ELEVENLABS_VOICE_ID`
+  - `ELEVENLABS_VOICE_ID` (recommended)
 - Runtime:
-  - `mpv` installed and executable
+  - local playback backend available (`mpv`, `afplay`, etc.)
 
 Quick checks:
 ```bash
 printenv ELEVENLABS_API_KEY | wc -c
 printenv ELEVENLABS_VOICE_ID | wc -c
-command -v mpv
+skills/local-tts-queue/scripts/playback-validate.sh
 ```
 
-## 2) Validate queue plumbing
+## 2) Run capability preflight (ElevenLabs + SFX)
+```bash
+skills/local-tts-queue/scripts/elevenlabs-preflight.sh
+```
+Interpretation:
+- `sfx_status="ok"` → SFX generation available now.
+- `sfx_status="rate_limited"` → retry later; script already retries short backoff on 429.
+- `sfx_status="forbidden_or_missing_permission"` → key lacks permission (or access denied).
+
+## 3) Validate queue plumbing
 ```bash
 /home/brad/.openclaw/workspace/scripts/tts-queue-status.sh
 ```
 Confirm queue file, lock file, and log path exist and are writable.
 
-## 3) Smoke test end-to-end
+## 4) Smoke test end-to-end
 ```bash
 /home/brad/.openclaw/workspace/scripts/speak-local-queued.sh "Queue smoke test"
 ```
 Then monitor worker log for dequeue/synth/playback completion.
 
-## 4) Worker failure triage
+## 5) Worker/startup failure triage
 Common failures:
 - Missing env vars: worker cannot synthesize
-- Missing `mpv`: synth may succeed but playback fails
+- Invalid/missing playback backend: synth may succeed but local playback fails
 - Queue lock stale: queue appears stuck
 
 Actions:
-1. Fix missing dependency.
-2. Restart daemon/worker.
-3. Re-enqueue one test item.
-4. Confirm queue drains.
+1. Run `skills/local-tts-queue/scripts/playback-validate.sh`.
+2. Fix missing dependency or choose a different backend in setup/config.
+3. Restart daemon/worker.
+4. Re-enqueue one test item.
+5. Confirm queue drains.
 
-## 5) Burst latency triage
+## 6) Playback contract
+Use `skills/local-tts-queue/scripts/play-local-audio.sh <file>` as the unified local player interface.
+
+Contract:
+- Input: readable local audio file path.
+- Backend resolution order: explicit flag -> config playback.backend -> auto-detect.
+- Output: zero exit on successful playback, non-zero with reason on failure.
+
+## 7) Burst latency triage
 If queue wait ramps quickly during bursts:
 - Reduce or disable earcons in worker critical path.
 - Enable/adjust burst coalescing window.
 - Add stale-item TTL for superseded chatter.
 - Consider prefetching next synth while current audio plays.
 
-## 6) Policy checks
+## 8) Policy checks
 For protected users (Brad/RECTANGL):
 - Use local speaker path only.
 - Do not emit Discord TTS attachments as fallback.

--- a/skills/local-tts-queue/scripts/elevenlabs-preflight.sh
+++ b/skills/local-tts-queue/scripts/elevenlabs-preflight.sh
@@ -5,6 +5,7 @@ BASE="https://api.elevenlabs.io"
 KEY="${ELEVENLABS_API_KEY:-}"
 VOICE="${ELEVENLABS_VOICE_ID:-}"
 MODEL="${ELEVENLABS_MODEL_ID:-}"
+SFX_RETRIES="${SFX_RETRIES:-2}"
 
 if [[ -z "$KEY" ]]; then
   echo '{"ok":false,"error":"missing ELEVENLABS_API_KEY"}'
@@ -13,7 +14,7 @@ fi
 
 h=(-H "xi-api-key: $KEY" -H 'accept: application/json')
 
-probe_get(){
+probe_get() {
   local ep="$1"
   local code
   code=$(curl -sS -o /tmp/el_preflight.json -w '%{http_code}' "${h[@]}" "$BASE$ep")
@@ -27,9 +28,33 @@ if [[ -n "$VOICE" ]]; then
   voice_code=$(probe_get "/v1/voices/$VOICE")
 fi
 
-sfx_code=$(curl -sS -o /tmp/el_sfx_pf.json -w '%{http_code}' -X POST "$BASE/v1/sound-generation" \
-  -H "xi-api-key: $KEY" -H 'Content-Type: application/json' \
-  -d '{"text":"short system chime","duration_seconds":1}')
+sfx_code="000"
+sfx_attempts=0
+sfx_status="unavailable"
+for delay in 0 1 2; do
+  (( sfx_attempts += 1 ))
+  sfx_code=$(curl -sS -o /tmp/el_sfx_pf.json -w '%{http_code}' -X POST "$BASE/v1/sound-generation" \
+    -H "xi-api-key: $KEY" -H 'Content-Type: application/json' \
+    -d '{"text":"short system chime","duration_seconds":1}')
+
+  if [[ "$sfx_code" == "200" ]]; then
+    sfx_status="ok"
+    break
+  fi
+
+  if [[ "$sfx_code" != "429" || "$sfx_attempts" -gt "$SFX_RETRIES" ]]; then
+    break
+  fi
+  sleep "$delay"
+done
+
+if [[ "$sfx_status" != "ok" ]]; then
+  case "$sfx_code" in
+    429) sfx_status="rate_limited" ;;
+    401|403) sfx_status="forbidden_or_missing_permission" ;;
+    *) sfx_status="unavailable" ;;
+  esac
+fi
 
 ok=true
 [[ "$models_code" == "200" ]] || ok=false
@@ -37,5 +62,5 @@ ok=true
 if [[ -n "$VOICE" && "$voice_code" != "200" ]]; then ok=false; fi
 
 cat <<EOF
-{"ok":$ok,"models_http":$models_code,"subscription_http":$user_code,"voice_http":"$voice_code","sfx_http":$sfx_code,"model_env_set":$([[ -n "$MODEL" ]] && echo true || echo false)}
+{"ok":$ok,"models_http":$models_code,"subscription_http":$user_code,"voice_http":"$voice_code","sfx_http":$sfx_code,"sfx_status":"$sfx_status","sfx_attempts":$sfx_attempts,"model_env_set":$([[ -n "$MODEL" ]] && echo true || echo false)}
 EOF

--- a/skills/local-tts-queue/scripts/playback-validate.sh
+++ b/skills/local-tts-queue/scripts/playback-validate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+CFG="$ROOT/config/tts-queue.json"
+BACKEND="${1:-}"
+
+if [[ -z "$BACKEND" && -f "$CFG" ]]; then
+  BACKEND=$(python3 - "$CFG" <<'PY'
+import json,sys
+try:
+  c=json.load(open(sys.argv[1]))
+  print(c.get('playback',{}).get('backend','auto'))
+except Exception:
+  print('auto')
+PY
+)
+fi
+
+if [[ -z "$BACKEND" || "$BACKEND" == "auto" ]]; then
+  BACKEND="$($ROOT/skills/local-tts-queue/scripts/backend-detect.sh || true)"
+fi
+
+ok=true
+reason=""
+
+case "$BACKEND" in
+  mpv|ffplay|paplay|afplay)
+    if ! command -v "$BACKEND" >/dev/null 2>&1; then
+      ok=false; reason="backend_binary_missing"
+    fi
+    ;;
+  powershell-soundplayer)
+    if ! command -v powershell >/dev/null 2>&1 && ! command -v pwsh >/dev/null 2>&1; then
+      ok=false; reason="powershell_missing"
+    fi
+    ;;
+  none|"")
+    ok=false; reason="no_backend_detected"
+    ;;
+  *)
+    if ! command -v "$BACKEND" >/dev/null 2>&1; then
+      ok=false; reason="custom_backend_missing"
+    fi
+    ;;
+esac
+
+cat <<EOF
+{"ok":$ok,"backend":"$BACKEND","reason":"$reason"}
+EOF
+
+$ok || exit 1

--- a/skills/local-tts-queue/scripts/test-v0.2.sh
+++ b/skills/local-tts-queue/scripts/test-v0.2.sh
@@ -12,6 +12,9 @@ echo "[test] backend detect"
 backend=$($SCRIPTS/backend-detect.sh || true)
 [[ -n "$backend" ]] || { echo "backend empty" >&2; exit 1; }
 
+echo "[test] playback validate"
+$SCRIPTS/playback-validate.sh >/dev/null || true
+
 echo "[test] earcon cache reuse sanity"
 mkdir -p "$ROOT/.openclaw"
 cat > "$ROOT/config/tts-queue.json" <<EOF


### PR DESCRIPTION
Finishes the remaining scope for the two open v0.2 issues.

Includes:
- new playback-validate.sh startup check for configured/auto backend resolution
- runbook updates documenting playback play(file) contract and startup triage
- elevenlabs-preflight.sh now includes short 429 retry/backoff semantics for SFX probe
- smoke test update to cover playback validation path

Closes #8
Closes #9