### PR TITLE
Sprint 2: backend/device selection + playback confirmation flow

### DIFF
--- a/skills/local-tts-queue/SKILL.md
+++ b/skills/local-tts-queue/SKILL.md
@@ -35,7 +35,9 @@ Use this skill to keep local speech fast, reliable, and policy-compliant by trea
 - ElevenLabs capability preflight: `skills/local-tts-queue/scripts/elevenlabs-preflight.sh` (includes short 429 retry/backoff for SFX probe)
 - Earcon library manager (durable categories/cache): `skills/local-tts-queue/scripts/earcon-library.sh`
 - Cross-platform playback runner: `skills/local-tts-queue/scripts/play-local-audio.sh`
+- Playback backend/device probe: `skills/local-tts-queue/scripts/playback-probe.sh`
 - Playback backend startup validator: `skills/local-tts-queue/scripts/playback-validate.sh`
+- Playback confirmation tone: `skills/local-tts-queue/scripts/playback-test.sh`
 - v0.2 smoke tests: `skills/local-tts-queue/scripts/test-v0.2.sh`
 
 ## References map

--- a/skills/local-tts-queue/references/runbook.md
+++ b/skills/local-tts-queue/references/runbook.md
@@ -11,7 +11,9 @@ Quick checks:
 ```bash
 printenv ELEVENLABS_API_KEY | wc -c
 printenv ELEVENLABS_VOICE_ID | wc -c
+skills/local-tts-queue/scripts/playback-probe.sh auto
 skills/local-tts-queue/scripts/playback-validate.sh
+skills/local-tts-queue/scripts/playback-test.sh
 ```
 
 ## 2) Run capability preflight (ElevenLabs + SFX)

--- a/skills/local-tts-queue/scripts/play-local-audio.sh
+++ b/skills/local-tts-queue/scripts/play-local-audio.sh
@@ -4,10 +4,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 CFG="$ROOT/config/tts-queue.json"
 BACKEND=""
+DEVICE=""
 FILE=""
 
 usage() {
-  echo "Usage: play-local-audio.sh <audio-file> [--backend name]"
+  echo "Usage: play-local-audio.sh <audio-file> [--backend name] [--device id]"
 }
 
 [[ $# -ge 1 ]] || { usage; exit 2; }
@@ -16,6 +17,7 @@ FILE="$1"; shift
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --backend) BACKEND="${2:-}"; shift 2 ;;
+    --device) DEVICE="${2:-}"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown arg: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -23,16 +25,21 @@ done
 
 [[ -f "$FILE" ]] || { echo "missing audio file: $FILE" >&2; exit 1; }
 
-if [[ -z "$BACKEND" && -f "$CFG" ]]; then
-  BACKEND=$(python3 - "$CFG" <<'PY'
+if [[ -f "$CFG" && ( -z "$BACKEND" || -z "$DEVICE" ) ]]; then
+  mapfile -t vals < <(python3 - "$CFG" <<'PY'
 import json,sys
 try:
   c=json.load(open(sys.argv[1]))
-  print(c.get('playback',{}).get('backend',''))
+  p=c.get('playback',{})
+  print(p.get('backend',''))
+  print(p.get('device',''))
 except Exception:
+  print('')
   print('')
 PY
 )
+  [[ -z "$BACKEND" ]] && BACKEND="${vals[0]:-}"
+  [[ -z "$DEVICE" ]] && DEVICE="${vals[1]:-}"
 fi
 
 if [[ -z "$BACKEND" || "$BACKEND" == "auto" ]]; then
@@ -41,6 +48,9 @@ fi
 
 case "$BACKEND" in
   mpv)
+    if [[ -n "$DEVICE" ]]; then
+      exec mpv --no-terminal --really-quiet --audio-device="$DEVICE" "$FILE"
+    fi
     exec mpv --no-terminal --really-quiet "$FILE"
     ;;
   ffplay)

--- a/skills/local-tts-queue/scripts/playback-probe.sh
+++ b/skills/local-tts-queue/scripts/playback-probe.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+BACKEND="${1:-auto}"
+
+if [[ "$BACKEND" == "auto" || -z "$BACKEND" ]]; then
+  BACKEND="$($ROOT/skills/local-tts-queue/scripts/backend-detect.sh || echo none)"
+fi
+
+list_mpv_devices() {
+  if ! command -v mpv >/dev/null 2>&1; then return 0; fi
+  mpv --no-config --audio-device=help --idle=yes --force-window=no 2>&1 \
+    | awk '/^  [^ ]/ {print $1}' \
+    | sed 's/:$//' \
+    | sed 's/^/device:/' || true
+}
+
+case "$BACKEND" in
+  mpv)
+    echo "backend:mpv"
+    list_mpv_devices
+    ;;
+  ffplay)
+    echo "backend:ffplay"
+    ;;
+  paplay)
+    echo "backend:paplay"
+    ;;
+  afplay)
+    echo "backend:afplay"
+    ;;
+  powershell-soundplayer)
+    echo "backend:powershell-soundplayer"
+    ;;
+  none|"")
+    echo "backend:none"
+    ;;
+  *)
+    echo "backend:$BACKEND"
+    ;;
+esac

--- a/skills/local-tts-queue/scripts/playback-test.sh
+++ b/skills/local-tts-queue/scripts/playback-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+TMP="$ROOT/.openclaw/playback-test-tone.wav"
+mkdir -p "$(dirname "$TMP")"
+
+# Generate short tone if missing (440Hz, 0.4s)
+if ! [[ -f "$TMP" ]]; then
+  ROOT_DIR="$ROOT" python3 - <<'PY'
+import wave, math, struct, os
+path=os.path.join(os.environ['ROOT_DIR'],'.openclaw','playback-test-tone.wav')
+fr=44100
+sec=0.4
+amp=16000
+freq=440.0
+n=int(fr*sec)
+with wave.open(path,'w') as w:
+    w.setnchannels(1)
+    w.setsampwidth(2)
+    w.setframerate(fr)
+    for i in range(n):
+        s=int(amp*math.sin(2*math.pi*freq*i/fr))
+        w.writeframes(struct.pack('<h', s))
+PY
+fi
+
+"$ROOT/skills/local-tts-queue/scripts/play-local-audio.sh" "$TMP" "$@"
+
+echo "If you heard the tone, playback path is good."

--- a/skills/local-tts-queue/scripts/playback-validate.sh
+++ b/skills/local-tts-queue/scripts/playback-validate.sh
@@ -4,17 +4,23 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 CFG="$ROOT/config/tts-queue.json"
 BACKEND="${1:-}"
+DEVICE="${2:-}"
 
-if [[ -z "$BACKEND" && -f "$CFG" ]]; then
-  BACKEND=$(python3 - "$CFG" <<'PY'
+if [[ -f "$CFG" && ( -z "$BACKEND" || -z "$DEVICE" ) ]]; then
+  mapfile -t vals < <(python3 - "$CFG" <<'PY'
 import json,sys
 try:
   c=json.load(open(sys.argv[1]))
-  print(c.get('playback',{}).get('backend','auto'))
+  p=c.get('playback',{})
+  print(p.get('backend','auto'))
+  print(p.get('device',''))
 except Exception:
   print('auto')
+  print('')
 PY
 )
+  [[ -z "$BACKEND" ]] && BACKEND="${vals[0]:-auto}"
+  [[ -z "$DEVICE" ]] && DEVICE="${vals[1]:-}"
 fi
 
 if [[ -z "$BACKEND" || "$BACKEND" == "auto" ]]; then
@@ -45,8 +51,15 @@ case "$BACKEND" in
     ;;
 esac
 
+if $ok && [[ "$BACKEND" == "mpv" && -n "$DEVICE" ]]; then
+  if ! mpv --no-config --audio-device=help --idle=yes --force-window=no 2>&1 | awk '{print $1}' | tr -d ':' | grep -Fxq "$DEVICE"; then
+    ok=false
+    reason="configured_device_not_found"
+  fi
+fi
+
 cat <<EOF
-{"ok":$ok,"backend":"$BACKEND","reason":"$reason"}
+{"ok":$ok,"backend":"$BACKEND","device":"$DEVICE","reason":"$reason"}
 EOF
 
 $ok || exit 1

--- a/skills/local-tts-queue/scripts/setup_first_run.py
+++ b/skills/local-tts-queue/scripts/setup_first_run.py
@@ -9,15 +9,29 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
 CFG = ROOT / "config" / "tts-queue.json"
+SCRIPTS = ROOT / "skills" / "local-tts-queue" / "scripts"
 
 
 def detect_backend() -> str:
-    script = ROOT / "skills" / "local-tts-queue" / "scripts" / "backend-detect.sh"
+    script = SCRIPTS / "backend-detect.sh"
     try:
         out = subprocess.check_output([str(script)], text=True).strip()
         return out or "auto"
     except Exception:
         return "auto"
+
+
+def probe_devices(backend: str) -> list[str]:
+    script = SCRIPTS / "playback-probe.sh"
+    try:
+        out = subprocess.check_output([str(script), backend], text=True)
+    except Exception:
+        return []
+    devices = []
+    for line in out.splitlines():
+        if line.startswith("device:"):
+            devices.append(line.split(":", 1)[1])
+    return devices
 
 
 def prompt(msg: str, default: str) -> str:
@@ -42,7 +56,9 @@ def main():
     p.add_argument("--style", default=None)
     p.add_argument("--voice-id", default=os.environ.get("ELEVENLABS_VOICE_ID", ""))
     p.add_argument("--backend", default=None)
+    p.add_argument("--device", default="")
     p.add_argument("--generate-starters", choices=["y", "n"], default=None)
+    p.add_argument("--run-playback-test", choices=["y", "n"], default=None)
     args = p.parse_args()
 
     backend_default = detect_backend()
@@ -50,7 +66,9 @@ def main():
     style = args.style
     voice_id = args.voice_id
     backend = args.backend
+    device = args.device
     generate = args.generate_starters
+    run_test = args.run_playback_test
 
     if not args.noninteractive:
         print("== local-tts-queue first run setup (python) ==")
@@ -61,12 +79,34 @@ def main():
             if has.lower().startswith("y"):
                 voice_id = input("Enter voice ID: ").strip()
         backend = backend or prompt("Playback backend", backend_default)
+
+        if not device:
+            devices = probe_devices(backend)
+            if devices:
+                print(f"Detected playback devices for {backend}:")
+                for i, d in enumerate(devices, start=1):
+                    print(f"  {i}) {d}")
+                idx = input("Choose device number (or press enter for default): ").strip()
+                if idx.isdigit() and 1 <= int(idx) <= len(devices):
+                    device = devices[int(idx) - 1]
+
+        run_test = run_test or prompt("Run playback test tone now? (y/n)", "y")
+        if run_test.lower().startswith("y"):
+            cmd = [str(SCRIPTS / "playback-test.sh"), "--backend", backend]
+            if device:
+                cmd += ["--device", device]
+            subprocess.call(cmd)
+            heard = prompt("Did you hear it? (y/n)", "y")
+            if not heard.lower().startswith("y"):
+                print("Tip: rerun setup and choose a different backend/device.")
+
         if earcons.lower().startswith("y"):
             generate = generate or prompt("Generate starter earcons now? (y/n)", "y")
     else:
         earcons = earcons or "y"
         style = style or "subtle chime"
         backend = backend or backend_default
+        run_test = run_test or "n"
         if earcons.lower().startswith("y"):
             generate = generate or "n"
         else:
@@ -86,7 +126,7 @@ def main():
             "categories": {"start": "", "end": "", "update": "", "important": "", "error": ""},
             "libraryPath": str(ROOT / ".openclaw" / "earcon-library.json"),
         },
-        "playback": {"backend": backend},
+        "playback": {"backend": backend, "device": device},
     }
 
     if args.dry_run:
@@ -98,7 +138,7 @@ def main():
     print("Next: run skills/local-tts-queue/scripts/elevenlabs-preflight.sh")
 
     if cfg["earcons"]["enabled"] and generate and generate.lower().startswith("y"):
-        gen_script = ROOT / "skills" / "local-tts-queue" / "scripts" / "earcon-library.sh"
+        gen_script = SCRIPTS / "earcon-library.sh"
         for cat in ["start", "end", "update", "important", "error"]:
             subprocess.call([str(gen_script), "generate", cat, f"{style} {cat} notification sound", "1"])
         print("Starter earcons generated (where API/key permits).")

--- a/skills/local-tts-queue/scripts/test-v0.2.sh
+++ b/skills/local-tts-queue/scripts/test-v0.2.sh
@@ -5,8 +5,8 @@ ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 SCRIPTS="$ROOT/skills/local-tts-queue/scripts"
 
 echo "[test] setup-first-run dry-run"
-json=$($SCRIPTS/setup-first-run.sh --noninteractive --dry-run --earcons y --style "test style" --backend auto --generate-starters n)
-echo "$json" | python3 -c 'import json,sys; j=json.load(sys.stdin); assert j["earcons"]["enabled"] is True; assert "playback" in j'
+json=$($SCRIPTS/setup-first-run.sh --noninteractive --dry-run --earcons y --style "test style" --backend auto --device "" --generate-starters n)
+echo "$json" | python3 -c 'import json,sys; j=json.load(sys.stdin); assert j["earcons"]["enabled"] is True; assert "playback" in j; assert "device" in j["playback"]'
 
 echo "[test] backend detect"
 backend=$($SCRIPTS/backend-detect.sh || true)
@@ -15,8 +15,11 @@ backend=$($SCRIPTS/backend-detect.sh || true)
 echo "[test] playback validate"
 $SCRIPTS/playback-validate.sh >/dev/null || true
 
+echo "[test] playback probe"
+$SCRIPTS/playback-probe.sh auto >/dev/null || true
+
 echo "[test] earcon cache reuse sanity"
-mkdir -p "$ROOT/.openclaw"
+mkdir -p "$ROOT/.openclaw" "$ROOT/config"
 cat > "$ROOT/config/tts-queue.json" <<EOF
 {
   "earcons": {


### PR DESCRIPTION
Implements Sprint 2 from epic #16 with Python-first onboarding (A+A direction).

Includes:
- setup_first_run.py now supports backend + device selection and optional playback test prompt
- setup-first-run.sh remains thin wrapper to python CLI
- new playback-probe.sh to surface backend/device options
- play-local-audio.sh honors configured/explicit playback device
- new playback-test.sh generates and plays a test tone for confirmation
- playback-validate checks configured mpv device existence
- runbook and smoke tests updated for probe + test flow

Validation:
- skills/local-tts-queue/scripts/test-v0.2.sh passes

Closes #18
Follow-up before release: #24 (macOS parity pass)