### PR TITLE
Frontmatter clarity follow-up for scanner/import consistency

### DIFF
--- a/skills/autonoannounce/SKILL.md
+++ b/skills/autonoannounce/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autonoannounce
-description: Build, operate, and troubleshoot Autonoannounce local speaker text-to-speech using the queued pipeline (enqueue to worker to ElevenLabs to playback backend). Requires ELEVENLABS_API_KEY for network synthesis, with optional ELEVENLABS_VOICE_ID and ELEVENLABS_MODEL_ID for voice/model selection. Writes local runtime state to config/tts-queue.json, .openclaw/*, and audio/earcons/*. Uses https://api.elevenlabs.io for synthesis/preflight calls. Use when creating or improving low-latency fire-and-forget TTS flows, tuning burst behavior, validating queue performance, enforcing local-only speech policy, or debugging queue/worker playback failures.
+description: Build, operate, and troubleshoot Autonoannounce local speaker text-to-speech using the queued pipeline (enqueue to worker to ElevenLabs to playback backend). Required env: ELEVENLABS_API_KEY. Optional env: ELEVENLABS_VOICE_ID and ELEVENLABS_MODEL_ID. Writes local runtime state to config/tts-queue.json, .openclaw/*, and audio/earcons/*. Uses https://api.elevenlabs.io for synthesis and preflight calls. Registry import helper metadata is provided in .clawhub/registry-metadata.json. Use when creating or improving low-latency fire-and-forget TTS flows, tuning burst behavior, validating queue performance, enforcing local-only speech policy, or debugging queue/worker playback failures.
 ---
 
 # Local TTS Queue


### PR DESCRIPTION
Follow-up PR to make frontmatter wording maximally explicit for scanner/import interpretation.

Changes:
- keep spec-compliant frontmatter (name + description only)
- tighten env wording to explicit Required/Optional labels
- mention .clawhub/registry-metadata.json as registry import helper source

No behavior changes.