### PR TITLE
Add metadata.openclaw env/bin requirements to SKILL frontmatter

### DIFF
--- a/skills/autonoannounce/SKILL.md
+++ b/skills/autonoannounce/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: autonoannounce
 description: Build, operate, and troubleshoot Autonoannounce local speaker text-to-speech using the queued pipeline (enqueue to worker to ElevenLabs to playback backend). Requires ELEVENLABS_API_KEY for network synthesis, with optional ELEVENLABS_VOICE_ID and ELEVENLABS_MODEL_ID for voice/model selection. Writes local runtime state to config/tts-queue.json, .openclaw/*, and audio/earcons/*. Uses https://api.elevenlabs.io for synthesis/preflight calls. Use when creating or improving low-latency fire-and-forget TTS flows, tuning burst behavior, validating queue performance, enforcing local-only speech policy, or debugging queue/worker playback failures.
+metadata: {"openclaw":{"skillKey":"autonoannounce","homepage":"https://github.com/ironystock/autonoannounce","requires":{"env":["ELEVENLABS_API_KEY"],"bins":["python3","curl"],"anyBins":["mpv","ffplay","afplay","paplay","powershell"]},"primaryEnv":"ELEVENLABS_API_KEY"}}
 ---
 
 # Local TTS Queue


### PR DESCRIPTION
Implements docs.openclaw.ai/tools/skills frontmatter gating guidance.

Adds single-line `metadata` JSON in SKILL frontmatter with:
- `openclaw.skillKey`: autonoannounce
- `openclaw.primaryEnv`: ELEVENLABS_API_KEY
- `openclaw.requires.env`: [ELEVENLABS_API_KEY]
- `openclaw.requires.bins`: [python3, curl]
- `openclaw.requires.anyBins`: [mpv, ffplay, afplay, paplay, powershell]
- `openclaw.homepage`: repo URL

This aligns importer-visible metadata with runtime credential/tool requirements.